### PR TITLE
Add diffusion training pipeline

### DIFF
--- a/src/diffusion_adv/diffusion_model.py
+++ b/src/diffusion_adv/diffusion_model.py
@@ -1,0 +1,177 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import math
+
+class SinusoidalPositionEmbedding(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+    def forward(self, time):
+        device = time.device
+        half_dim = self.dim // 2
+        emb = math.log(10000) / (half_dim - 1)
+        emb = torch.exp(torch.arange(half_dim, device=device) * -emb)
+        emb = time[:, None] * emb[None, :]
+        emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
+        return emb
+
+class ResidualBlock(nn.Module):
+    def __init__(self, dim, dropout=0.1):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.LayerNorm(dim),
+            nn.Linear(dim, dim * 4),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * 4, dim),
+            nn.Dropout(dropout)
+        )
+    def forward(self, x):
+        return x + self.layers(x)
+
+class CrossAttentionBlock(nn.Module):
+    def __init__(self, dim, time_dim, num_heads=8, dropout=0.1):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim ** -0.5
+        self.norm_weights = nn.LayerNorm(dim)
+        self.norm_time = nn.LayerNorm(time_dim)
+        self.to_q = nn.Linear(dim, dim, bias=False)
+        self.to_k = nn.Linear(time_dim, dim, bias=False)
+        self.to_v = nn.Linear(time_dim, dim, bias=False)
+        self.to_out = nn.Sequential(
+            nn.Linear(dim, dim),
+            nn.Dropout(dropout)
+        )
+    def forward(self, weights, time_emb):
+        batch_size = weights.shape[0]
+        weights = self.norm_weights(weights)
+        time_emb = self.norm_time(time_emb)
+        q = self.to_q(weights)
+        k = self.to_k(time_emb)
+        v = self.to_v(time_emb)
+        q = q.view(batch_size, 1, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(batch_size, 1, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(batch_size, 1, self.num_heads, self.head_dim).transpose(1, 2)
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+        attn = F.softmax(attn, dim=-1)
+        out = (attn @ v).transpose(1, 2).contiguous().view(batch_size, -1)
+        return self.to_out(out)
+
+class AdaptiveLayerNorm(nn.Module):
+    def __init__(self, dim, time_dim):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim, elementwise_affine=False)
+        self.time_proj = nn.Linear(time_dim, dim * 2)
+    def forward(self, x, time_emb):
+        normed = self.norm(x)
+        time_params = self.time_proj(time_emb)
+        scale, shift = time_params.chunk(2, dim=-1)
+        return normed * (1 + scale) + shift
+
+class AdvancedWeightSpaceDiffusion(nn.Module):
+    def __init__(self,
+                 target_model_flat_dim,
+                 time_emb_dim=256,
+                 hidden_dim=1024,
+                 num_layers=6,
+                 num_heads=8,
+                 dropout=0.1,
+                 use_cross_attention=True,
+                 use_adaptive_norm=True):
+        super().__init__()
+        self.target_model_flat_dim = target_model_flat_dim
+        self.time_emb_dim = time_emb_dim
+        self.hidden_dim = hidden_dim
+        self.use_cross_attention = use_cross_attention
+        self.use_adaptive_norm = use_adaptive_norm
+        self.time_embedding = SinusoidalPositionEmbedding(time_emb_dim)
+        self.time_mlp = nn.Sequential(
+            nn.Linear(time_emb_dim, time_emb_dim),
+            nn.GELU(),
+            nn.Linear(time_emb_dim, time_emb_dim)
+        )
+        self.input_proj = nn.Linear(target_model_flat_dim, hidden_dim)
+        if use_cross_attention:
+            self.cross_attention = CrossAttentionBlock(
+                hidden_dim, time_emb_dim, num_heads, dropout
+            )
+        self.layers = nn.ModuleList()
+        for i in range(num_layers):
+            if use_adaptive_norm:
+                layer = nn.ModuleList([
+                    AdaptiveLayerNorm(hidden_dim, time_emb_dim),
+                    nn.Linear(hidden_dim, hidden_dim * 4),
+                    nn.GELU(),
+                    nn.Dropout(dropout),
+                    nn.Linear(hidden_dim * 4, hidden_dim),
+                    nn.Dropout(dropout)
+                ])
+            else:
+                layer = ResidualBlock(hidden_dim, dropout)
+            self.layers.append(layer)
+        self.output_norm = nn.LayerNorm(hidden_dim)
+        self.output_proj = nn.Linear(hidden_dim, target_model_flat_dim)
+        self.apply(self._init_weights)
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear):
+            torch.nn.init.xavier_uniform_(module.weight)
+            if module.bias is not None:
+                torch.nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.LayerNorm):
+            torch.nn.init.ones_(module.weight)
+            torch.nn.init.zeros_(module.bias)
+    def forward(self, noisy_weights_flat, t):
+        if t.ndim == 2:
+            t = t.squeeze(-1)
+        time_emb = self.time_embedding(t)
+        time_emb = self.time_mlp(time_emb)
+        x = self.input_proj(noisy_weights_flat)
+        if self.use_cross_attention:
+            attn_out = self.cross_attention(x, time_emb)
+            x = x + attn_out
+        for layer in self.layers:
+            if self.use_adaptive_norm:
+                norm_layer, linear1, activation, dropout1, linear2, dropout2 = layer
+                residual = x
+                x = norm_layer(x, time_emb)
+                x = linear1(x)
+                x = activation(x)
+                x = dropout1(x)
+                x = linear2(x)
+                x = dropout2(x)
+                x = x + residual
+            else:
+                x = layer(x)
+        x = self.output_norm(x)
+        predicted_denoised_weights_flat = self.output_proj(x)
+        return predicted_denoised_weights_flat
+
+def get_target_model_flat_dim(target_model_state_dict):
+    return sum(p.numel() for p in target_model_state_dict.values())
+
+def flatten_state_dict(state_dict):
+    return torch.cat([p.flatten() for p in state_dict.values()])
+
+def unflatten_to_state_dict(flat_params, reference_state_dict):
+    new_state_dict = {}
+    current_pos = 0
+    for key, param_ref in reference_state_dict.items():
+        num_elements = param_ref.numel()
+        shape = param_ref.shape
+        new_state_dict[key] = flat_params[current_pos : current_pos + num_elements].view(shape)
+        current_pos += num_elements
+    if current_pos != flat_params.numel():
+        raise ValueError("Mismatch in number of elements during unflattening.")
+    return new_state_dict
+# KEY
+# SinusoidalPositionEmbedding: time embedding
+# ResidualBlock: residual block
+# CrossAttentionBlock: cross attention block
+# AdaptiveLayerNorm: adaptive layer norm
+# AdvancedWeightSpaceDiffusion: diffusion model
+# get_target_model_flat_dim: parameter counter
+# flatten_state_dict: flattener
+# unflatten_to_state_dict: unflattener

--- a/src/diffusion_adv/evaluate_generalization.py
+++ b/src/diffusion_adv/evaluate_generalization.py
@@ -1,0 +1,157 @@
+import torch
+import torch.nn as nn
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+import os
+import glob
+import matplotlib.pyplot as plt
+from .target_model import TargetModel
+from .diffusion_model import AdvancedWeightSpaceDiffusion, flatten_state_dict, unflatten_to_state_dict, get_target_model_flat_dim
+
+def evaluate_model_performance(model, test_loader, device, criterion):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    total_samples = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            outputs = model(data)
+            loss = criterion(outputs, target)
+            test_loss += loss.item() * data.size(0)
+            pred = outputs.argmax(dim=1, keepdim=True)
+            correct += pred.eq(target.view_as(pred)).sum().item()
+            total_samples += data.size(0)
+    avg_loss = test_loss / total_samples
+    accuracy = 100. * correct / total_samples
+    return accuracy, avg_loss
+
+def generate_checkpoints_with_diffusion(
+    diffusion_model,
+    initial_weights_flat,
+    num_steps,
+    target_model_reference_state_dict,
+    device
+):
+    generated_weights_sequence_flat = []
+    current_weights_flat = initial_weights_flat.to(device)
+    diffusion_model.to(device)
+    diffusion_model.eval()
+    for t_idx in range(num_steps):
+        timestep_tensor = torch.tensor([[float(t_idx)]], device=device)
+        with torch.no_grad():
+            predicted_next_weights_flat = diffusion_model(current_weights_flat.unsqueeze(0), timestep_tensor)
+            predicted_next_weights_flat = predicted_next_weights_flat.squeeze(0)
+        generated_weights_sequence_flat.append(predicted_next_weights_flat.cpu())
+        current_weights_flat = predicted_next_weights_flat
+        if (t_idx + 1) % 10 == 0 or (t_idx + 1) == num_steps:
+            print(f"  Generated step {t_idx+1}/{num_steps}")
+    return generated_weights_sequence_flat
+
+def evaluate_diffusion_generated_checkpoints(
+    diffusion_model_path,
+    target_model_reference,
+    checkpoints_OG,
+    batch_size_eval=128,
+    plot_results=True
+):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    target_model_reference.to(device)
+    reference_state_dict = target_model_reference.state_dict()
+    target_flat_dim = get_target_model_flat_dim(reference_state_dict)
+    time_emb_dim_diff = 256
+    hidden_dim_diff = 1024
+    num_layers_diff = 6
+    num_heads_diff = 8
+    dropout_diff = 0.1
+    use_cross_attention = True
+    use_adaptive_norm = True
+    diffusion_model = AdvancedWeightSpaceDiffusion(
+        target_model_flat_dim=target_flat_dim,
+        time_emb_dim=time_emb_dim_diff,
+        hidden_dim=hidden_dim_diff,
+        num_layers=num_layers_diff,
+        num_heads=num_heads_diff,
+        dropout=dropout_diff,
+        use_cross_attention=use_cross_attention,
+        use_adaptive_norm=use_adaptive_norm
+    )
+    diffusion_model.load_state_dict(torch.load(diffusion_model_path, map_location=device))
+    diffusion_model.eval()
+    new_random_model = TargetModel()
+    initial_model_state_dict = new_random_model.state_dict()
+    initial_weights_flat = flatten_state_dict(initial_model_state_dict).to(device)
+    original_weight_files = sorted(
+        glob.glob(os.path.join(checkpoints_OG, "weights_epoch_*.safetensors")),
+        key=lambda x: int(x.split('_')[-1].split('.')[0]) if x.split('_')[-1].split('.')[0].isdigit() else -1
+    )
+    num_generation_steps = len(original_weight_files) - 1
+    if num_generation_steps <= 0:
+        print(f"Not enough weight files in {checkpoints_OG} to determine generation steps.")
+        return
+    generated_weights_flat_sequence = generate_checkpoints_with_diffusion(
+        diffusion_model,
+        initial_weights_flat,
+        num_generation_steps,
+        reference_state_dict,
+        device
+    )
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    test_dataset = datasets.MNIST('./data', train=False, download=False, transform=transform)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size_eval, shuffle=True)
+    criterion = nn.CrossEntropyLoss(reduction='sum')
+    eval_model = TargetModel().to(device)
+    accuracies_generated = []
+    losses_generated = []
+    eval_model.load_state_dict(unflatten_to_state_dict(initial_weights_flat.cpu(), reference_state_dict))
+    acc, loss = evaluate_model_performance(eval_model, test_loader, device, criterion)
+    accuracies_generated.append(acc)
+    losses_generated.append(loss)
+    print(f"Step 0 (Initial Random Weights): Accuracy = {acc:.2f}%, Avg Loss = {loss:.4f}")
+    for i, flat_weights in enumerate(generated_weights_flat_sequence):
+        generated_state_dict = unflatten_to_state_dict(flat_weights.cpu(), reference_state_dict)
+        eval_model.load_state_dict(generated_state_dict)
+        acc, loss = evaluate_model_performance(eval_model, test_loader, device, criterion)
+        accuracies_generated.append(acc)
+        losses_generated.append(loss)
+        print(f"Generated Step {i+1}/{num_generation_steps}: Accuracy = {acc:.2f}%, Avg Loss = {loss:.4f}")
+    if plot_results:
+        plt.figure(figsize=(24, 10))
+        plt.subplot(1, 2, 2)
+        plt.plot(accuracies_generated, label="Diffusion Generated checkpoints", marker='o')
+        plt.xlabel("Optimization Step / Epoch")
+        plt.ylabel("Test Accuracy (%)")
+        plt.title("Accuracy of Diffusion-Generated Weights")
+        plt.legend()
+        plt.grid(True)
+        plt.subplot(1, 2, 1)
+        plt.plot(losses_generated, label="Diffusion Generated checkpoints", marker='o')
+        plt.xlabel("Optimization Step / Epoch")
+        plt.ylabel("Average Test Loss")
+        plt.title("Loss of Diffusion-Generated Weights")
+        plt.legend()
+        plt.grid(True)
+        plt.tight_layout()
+        plot_save_path = "diffusion_evaluation_plot.png"
+        plt.savefig(plot_save_path)
+        print(f"Plot saved to {plot_save_path}")
+    save_choice = input("Save the generated weights from this checkpoints? (yes/no): ").lower()
+    if save_choice in ['yes', 'y']:
+        save_dir = 'generalized_checkpoints_weights'
+        os.makedirs(save_dir, exist_ok=True)
+        torch.save(initial_model_state_dict, os.path.join(save_dir, 'weights_step_0.safetensors'))
+        for i, flat_weights in enumerate(generated_weights_flat_sequence):
+            state_dict = unflatten_to_state_dict(flat_weights.cpu(), reference_state_dict)
+            torch.save(state_dict, os.path.join(save_dir, f'weights_step_{i+1}.safetensors'))
+        print(f"Saved {len(generated_weights_flat_sequence) + 1} weight files to '{save_dir}'.")
+    else:
+        print("Generated weights were not saved.")
+    print("Evaluation finished.")
+
+# KEY
+# evaluate_model_performance: evaluator
+# generate_checkpoints_with_diffusion: generator
+# evaluate_diffusion_generated_checkpoints: evaluation pipeline

--- a/src/diffusion_adv/target_model.py
+++ b/src/diffusion_adv/target_model.py
@@ -1,0 +1,29 @@
+import torch
+import torch.nn as nn
+
+class TargetModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+    def forward(self, x):
+        x = self.conv1(x)
+        x = nn.functional.relu(x)
+        x = self.conv2(x)
+        x = nn.functional.relu(x)
+        x = nn.functional.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = nn.functional.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = nn.functional.log_softmax(x, dim=1)
+        return output
+
+# KEY
+# TargetModel: cnn

--- a/src/diffusion_adv/train_diffusion.py
+++ b/src/diffusion_adv/train_diffusion.py
@@ -1,0 +1,102 @@
+import torch
+import torch.optim as optim
+import torch.nn as nn
+from torch.utils.data import Dataset, DataLoader
+import os
+import glob
+import time
+from .diffusion_model import AdvancedWeightSpaceDiffusion, flatten_state_dict, get_target_model_flat_dim
+from .target_model import TargetModel
+
+class WeightCheckpointsDataset(Dataset):
+    def __init__(self, checkpoints_dir, reference_state_dict, max_checkpoints_len=None):
+        self.checkpoints_dir = checkpoints_dir
+        self.reference_state_dict = reference_state_dict
+        self.flat_dim = get_target_model_flat_dim(reference_state_dict)
+        weight_files = sorted(
+            glob.glob(os.path.join(checkpoints_dir, "weights_epoch_*.safetensors")),
+            key=lambda x: int(x.split('_')[-1].split('.')[0]) if x.split('_')[-1].split('.')[0].isdigit() else -1
+        )
+        if not weight_files:
+            raise FileNotFoundError(f"No weight files found in {checkpoints_dir}.")
+        self.weight_files = weight_files
+        if max_checkpoints_len:
+            self.weight_files = self.weight_files[:max_checkpoints_len + 1]
+        self.num_total_steps = len(self.weight_files) - 1
+    def __len__(self):
+        return self.num_total_steps
+    def __getitem__(self, idx):
+        if idx >= self.__len__():
+            raise IndexError(f"Index {idx} out of range")
+        w_path_current = self.weight_files[idx]
+        w_path_next = self.weight_files[idx+1]
+        state_dict_current = torch.load(w_path_current, map_location='cpu')
+        current_w = flatten_state_dict(state_dict_current)
+        state_dict_next = torch.load(w_path_next, map_location='cpu')
+        target_next_w = flatten_state_dict(state_dict_next)
+        if current_w.shape[0] != self.flat_dim or target_next_w.shape[0] != self.flat_dim:
+            raise ValueError("Dimension mismatch in loaded weights")
+        t = torch.tensor([float(idx) / (self.num_total_steps - 1) if self.num_total_steps > 1 else 0.0])
+        return current_w, target_next_w, t
+
+def train_diffusion_model(
+    checkpoints_dir,
+    target_model_reference,
+    epochs=100,
+    lr=0.001,
+    batch_size=128,
+    time_emb_dim=256,
+    hidden_dim_diff_model=1024,
+    num_layers=6,
+    num_heads=8,
+    dropout=0.1,
+    use_cross_attention=True,
+    use_adaptive_norm=True,
+    save_path="trained_diffusion_model.safetensors",
+    max_traj_len_for_training=None,
+    device=None
+):
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if isinstance(target_model_reference, nn.Module):
+        reference_state_dict = target_model_reference.state_dict()
+    else:
+        reference_state_dict = target_model_reference
+    target_flat_dim = get_target_model_flat_dim(reference_state_dict)
+    diffusion_model = AdvancedWeightSpaceDiffusion(
+        target_model_flat_dim=target_flat_dim,
+        time_emb_dim=time_emb_dim,
+        hidden_dim=hidden_dim_diff_model,
+        num_layers=num_layers,
+        num_heads=num_heads,
+        dropout=dropout,
+        use_cross_attention=use_cross_attention,
+        use_adaptive_norm=use_adaptive_norm
+    ).to(device)
+    dataset = WeightCheckpointsDataset(checkpoints_dir, reference_state_dict, max_checkpoints_len=max_traj_len_for_training)
+    if len(dataset) == 0:
+        return
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    criterion = nn.MSELoss()
+    optimizer = optim.Adam(diffusion_model.parameters(), lr=lr)
+    for epoch in range(1, epochs + 1):
+        start_time = time.time()
+        diffusion_model.train()
+        total_loss = 0
+        for batch_idx, (current_weights_flat, target_next_weights_flat, timesteps_t) in enumerate(dataloader):
+            current_weights_flat = current_weights_flat.to(device)
+            target_next_weights_flat = target_next_weights_flat.to(device)
+            timesteps_t = timesteps_t.to(device)
+            optimizer.zero_grad()
+            predicted_next_weights_flat = diffusion_model(current_weights_flat, timesteps_t)
+            loss = criterion(predicted_next_weights_flat, target_next_weights_flat)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item()
+        avg_loss = total_loss / len(dataloader)
+        print(f"Epoch [{epoch}/{epochs}], Average Loss: {avg_loss:.6f} | Time: {time.time()-start_time:.2f}s")
+    torch.save(diffusion_model.state_dict(), save_path)
+
+# KEY
+# WeightCheckpointsDataset: dataset
+# train_diffusion_model: diffusion trainer

--- a/src/diffusion_adv/train_target_model.py
+++ b/src/diffusion_adv/train_target_model.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+import os
+from .target_model import TargetModel
+
+def train_target_model(epochs=5, lr=0.01, batch_size=64, save_dir='checkpoints_weights_cnn'):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    train_dataset = datasets.MNIST('./data', train=True, download=True, transform=transform)
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    model = TargetModel().to(device)
+    optimizer = optim.SGD(model.parameters(), lr=lr, momentum=0.9)
+    criterion = nn.NLLLoss()
+    os.makedirs(save_dir, exist_ok=True)
+    for epoch in range(1, epochs + 1):
+        model.train()
+        for data, target in train_loader:
+            data, target = data.to(device), target.to(device)
+            optimizer.zero_grad()
+            output = model(data)
+            loss = criterion(output, target)
+            loss.backward()
+            optimizer.step()
+        torch.save(model.state_dict(), os.path.join(save_dir, f'weights_epoch_{epoch}.safetensors'))
+
+# KEY
+# train_target_model: cnn trainer


### PR DESCRIPTION
## Summary
- introduce AdvancedWeightSpaceDiffusion model with sinusoidal time embeddings, optional cross-attention, and adaptive normalization
- provide dataset and trainer for checkpoint-based diffusion learning
- add evaluation routine, target CNN, and utility training script for checkpoint generation

## Testing
- `python -m py_compile src/diffusion_adv/*.py`
- `PYTHONPATH=src python - <<'PY'
from diffusion_adv.train_diffusion import train_diffusion_model
from diffusion_adv.target_model import TargetModel
train_diffusion_model(checkpoints_dir='checkpoints_weights_cnn', target_model_reference=TargetModel(), epochs=5, lr=0.001, batch_size=2, time_emb_dim=64, hidden_dim_diff_model=128, num_layers=2, num_heads=4, use_cross_attention=False, use_adaptive_norm=False)
PY`
- `PYTHONPATH=src python - <<'PY'
import torch
from diffusion_adv.evaluate_generalization import generate_checkpoints_with_diffusion
from diffusion_adv.target_model import TargetModel
from diffusion_adv.diffusion_model import AdvancedWeightSpaceDiffusion, flatten_state_dict, unflatten_to_state_dict, get_target_model_flat_dim
from torchvision import datasets, transforms
from torch.utils.data import DataLoader
import torch.nn as nn

device = torch.device('cpu')
reference_model = TargetModel()
reference_state_dict = reference_model.state_dict()
target_flat_dim = get_target_model_flat_dim(reference_state_dict)
diff_model = AdvancedWeightSpaceDiffusion(target_model_flat_dim=target_flat_dim, time_emb_dim=64, hidden_dim=128, num_layers=2, num_heads=4, dropout=0.1, use_cross_attention=False, use_adaptive_norm=False)
diff_model.load_state_dict(torch.load('trained_diffusion_model.safetensors', map_location=device))
init_model = TargetModel()
init_flat = flatten_state_dict(init_model.state_dict()).to(device)
generated = generate_checkpoints_with_diffusion(diff_model, init_flat, num_steps=2, target_model_reference_state_dict=reference_state_dict, device=device)
transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
test_dataset = datasets.MNIST('./data', train=False, download=False, transform=transform)
subset = torch.utils.data.Subset(test_dataset, list(range(100)))
test_loader = DataLoader(subset, batch_size=32, shuffle=False)
criterion = nn.CrossEntropyLoss(reduction='sum')

def eval_model(state_dict):
    model = TargetModel().to(device)
    model.load_state_dict(state_dict)
    model.eval()
    total_loss=0; correct=0; total=0
    with torch.no_grad():
        for data,target in test_loader:
            data, target = data.to(device), target.to(device)
            out = model(data)
            loss = criterion(out, target)
            total_loss += loss.item()
            pred = out.argmax(dim=1, keepdim=True)
            correct += pred.eq(target.view_as(pred)).sum().item()
            total += data.size(0)
    return correct/total*100, total_loss/total

acc0, loss0 = eval_model(unflatten_to_state_dict(init_flat, reference_state_dict))
acc1, loss1 = eval_model(unflatten_to_state_dict(generated[0], reference_state_dict))
acc2, loss2 = eval_model(unflatten_to_state_dict(generated[1], reference_state_dict))
print('Init acc', acc0, 'loss', loss0)
print('Gen1 acc', acc1, 'loss', loss1)
print('Gen2 acc', acc2, 'loss', loss2)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68921d5a7b9c8321bc7007baee0666f7