### PR TITLE
Add dataset download flag

### DIFF
--- a/src/diffusion_adv/evaluate_generalization.py
+++ b/src/diffusion_adv/evaluate_generalization.py
@@ -53,7 +53,8 @@ def evaluate_diffusion_generated_checkpoints(
     target_model_reference,
     checkpoints_OG,
     batch_size_eval=128,
-    plot_results=True
+    plot_results=True,
+    download=False
 ):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     target_model_reference.to(device)
@@ -100,7 +101,7 @@ def evaluate_diffusion_generated_checkpoints(
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
     ])
-    test_dataset = datasets.MNIST('./data', train=False, download=False, transform=transform)
+    test_dataset = datasets.MNIST('./data', train=False, download=download, transform=transform)
     test_loader = DataLoader(test_dataset, batch_size=batch_size_eval, shuffle=True)
     criterion = nn.CrossEntropyLoss(reduction='sum')
     eval_model = TargetModel().to(device)
@@ -152,6 +153,7 @@ def evaluate_diffusion_generated_checkpoints(
     print("Evaluation finished.")
 
 # KEY
+# download: dataset flag
 # evaluate_model_performance: evaluator
 # generate_checkpoints_with_diffusion: generator
 # evaluate_diffusion_generated_checkpoints: evaluation pipeline

--- a/src/diffusion_adv/train_target_model.py
+++ b/src/diffusion_adv/train_target_model.py
@@ -6,13 +6,13 @@ from torchvision import datasets, transforms
 import os
 from .target_model import TargetModel
 
-def train_target_model(epochs=5, lr=0.01, batch_size=64, save_dir='checkpoints_weights_cnn'):
+def train_target_model(epochs=5, lr=0.01, batch_size=64, save_dir='checkpoints_weights_cnn', download=False):
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
     ])
-    train_dataset = datasets.MNIST('./data', train=True, download=True, transform=transform)
+    train_dataset = datasets.MNIST('./data', train=True, download=download, transform=transform)
     train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
     model = TargetModel().to(device)
     optimizer = optim.SGD(model.parameters(), lr=lr, momentum=0.9)
@@ -30,4 +30,5 @@ def train_target_model(epochs=5, lr=0.01, batch_size=64, save_dir='checkpoints_w
         torch.save(model.state_dict(), os.path.join(save_dir, f'weights_epoch_{epoch}.safetensors'))
 
 # KEY
+# download: dataset flag
 # train_target_model: cnn trainer


### PR DESCRIPTION
## Summary
- add `download` flag to training and evaluation routines
- route `download` through MNIST dataset constructors so callers can enable downloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899178d875c8321991fa9ee0060889b