### PR TITLE
refactor: simplify names and remove comments

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,38 +1,20 @@
 import argparse
 import yaml
-import os
 from pathlib import Path
 
-def main():
-    """
-    Main dispatcher function.
-    """
-    parser = argparse.ArgumentParser(description="Run an experiment.")
-    parser.add_argument('--experiment_path', type=str, required=True,
-                        help='Path to the experiment directory.')
-    args = parser.parse_args()
-
-    experiment_path = Path(args.experiment_path)
-    config_path = experiment_path / 'config.yaml'
-
-    if not config_path.is_file():
-        print(f"Error: Configuration file not found at {config_path}")
+def entry():
+    par = argparse.ArgumentParser()
+    par.add_argument('--experiment_path', type=str, required=True, help='Path to the experiment directory.')
+    args = par.parse_args()
+    path_exp = Path(args.experiment_path)
+    path_cfg = path_exp / 'config.yaml'
+    if not path_cfg.is_file():
+        print(f"Error: Configuration file not found at {path_cfg}")
         return
-
-    with open(config_path, 'r') as f:
-        config = yaml.safe_load(f)
-
+    with open(path_cfg, 'r') as fh:
+        cfg = yaml.safe_load(fh)
     print("Loaded configuration:")
-    print(yaml.dump(config, indent=2))
-
-    # TODO: Dispatch to the appropriate function in src/ based on the config
-    # For example:
-    # if config.get('task') == 'train_generator':
-    #     from src.diffusion.train_generator import train_generator
-    #     train_generator(config)
-    # elif config.get('task') == 'synthesize_weights':
-    #     from src.diffusion.synthesize_weights import synthesize_weights
-    #     synthesize_weights(config)
+    print(yaml.dump(cfg, indent=2))
 
 if __name__ == '__main__':
-    main()
+    entry()

--- a/src/architectures/cnn.py
+++ b/src/architectures/cnn.py
@@ -1,8 +1,9 @@
+import torch
 import torch.nn as nn
 
-class ReferenceModel(nn.Module):
+class model_ref(nn.Module):
     def __init__(self):
-        super(ReferenceModel, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.dropout1 = nn.Dropout(0.25)
@@ -22,5 +23,4 @@ class ReferenceModel(nn.Module):
         x = nn.functional.relu(x)
         x = self.dropout2(x)
         x = self.fc2(x)
-        output = nn.functional.log_softmax(x, dim=1)
-        return output
+        return nn.functional.log_softmax(x, dim=1)

--- a/src/diffusion/create_checkpoints.py
+++ b/src/diffusion/create_checkpoints.py
@@ -1,9 +1,4 @@
-def create_checkpoints(config):
-    """
-    This function is responsible for training the ReferenceModel and saving
-    the checkpoints that will be used to train the WeightGenerator.
-    """
+def ckpt_make(cfg):
     print("Creating checkpoints...")
-    print(f"Configuration: {config}")
-    # Placeholder for the training logic of the ReferenceModel
+    print(f"Configuration: {cfg}")
     pass


### PR DESCRIPTION
## Summary
- streamline experiment runner by removing comments and renaming entry
- rename convolutional model and add minimal imports
- shorten checkpoint creator naming without comments

## Testing
- `python -m py_compile run.py src/architectures/cnn.py src/diffusion/create_checkpoints.py`


------
https://chatgpt.com/codex/tasks/task_e_68991750c29483219473afcac72dae6f