### PR TITLE
Implement training pipeline utilities

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 import argparse
 import yaml
 from pathlib import Path
+from src.diffusion.train_generator import train as train_gen
 
 def entry():
     par = argparse.ArgumentParser()
@@ -13,8 +14,9 @@ def entry():
         return
     with open(path_cfg, 'r') as fh:
         cfg = yaml.safe_load(fh)
-    print("Loaded configuration:")
-    print(yaml.dump(cfg, indent=2))
+    t = cfg.get('task')
+    if t == 'train_generator':
+        train_gen(cfg)
 
 if __name__ == '__main__':
     entry()

--- a/src/architectures/resnet.py
+++ b/src/architectures/resnet.py
@@ -1,0 +1,46 @@
+import torch
+import torch.nn as nn
+
+class blk(nn.Module):
+    def __init__(self, f, g, s=1):
+        super().__init__()
+        self.c1 = nn.Conv2d(f, g, 3, s, 1, bias=False)
+        self.b1 = nn.BatchNorm2d(g)
+        self.c2 = nn.Conv2d(g, g, 3, 1, 1, bias=False)
+        self.b2 = nn.BatchNorm2d(g)
+        self.p = nn.Sequential()
+        if s != 1 or f != g:
+            self.p = nn.Sequential(nn.Conv2d(f, g, 1, s, bias=False), nn.BatchNorm2d(g))
+
+    def forward(self, x):
+        y = self.c1(x)
+        y = self.b1(y)
+        y = nn.functional.relu(y)
+        y = self.c2(y)
+        y = self.b2(y)
+        y = self.p(x) + y
+        return nn.functional.relu(y)
+
+class model_ref(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.c = nn.Conv2d(1, 16, 3, 1, 1, bias=False)
+        self.b = nn.BatchNorm2d(16)
+        self.l1 = blk(16, 16)
+        self.l2 = blk(16, 32, 2)
+        self.l3 = blk(32, 64, 2)
+        self.p = nn.AdaptiveAvgPool2d((1, 1))
+        self.f = nn.Linear(64, 10)
+
+    def forward(self, x):
+        x = self.c(x)
+        x = self.b(x)
+        x = nn.functional.relu(x)
+        x = self.l1(x)
+        x = self.l2(x)
+        x = self.l3(x)
+        x = self.p(x)
+        x = torch.flatten(x, 1)
+        x = self.f(x)
+        return nn.functional.log_softmax(x, 1)
+

--- a/src/diffusion/generator.py
+++ b/src/diffusion/generator.py
@@ -1,10 +1,10 @@
 import torch.nn as nn
 
-class WeightGenerator(nn.Module):
-    def __init__(self):
-        super(WeightGenerator, self).__init__()
-        # Placeholder for the diffusion model architecture
-        self.fc1 = nn.Linear(10, 10)
+class model_ref(nn.Module):
+    def __init__(self, n):
+        super().__init__()
+        self.l = nn.Linear(n, n)
 
     def forward(self, x):
-        return self.fc1(x)
+        return self.l(x)
+

--- a/src/diffusion/train_generator.py
+++ b/src/diffusion/train_generator.py
@@ -1,0 +1,22 @@
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from .generator import model_ref as gen
+from src.utils.data import ckpt_set
+
+def train(cfg):
+    ds = ckpt_set(cfg['dataset'])
+    dl = DataLoader(ds, batch_size=cfg['hyperparameters']['batch_size'], shuffle=True)
+    n = ds[0].numel()
+    m = gen(n)
+    opt = torch.optim.Adam(m.parameters(), lr=cfg['hyperparameters']['learning_rate'])
+    loss = nn.MSELoss()
+    for _ in range(cfg['hyperparameters']['epochs']):
+        for d in dl:
+            o = m(d)
+            l = loss(o, d)
+            opt.zero_grad()
+            l.backward()
+            opt.step()
+    return m
+

--- a/src/utils/data.py
+++ b/src/utils/data.py
@@ -1,14 +1,17 @@
+from pathlib import Path
+import torch
 from torch.utils.data import Dataset
+from .flatten import flat
 
-class CheckpointSet(Dataset):
-    def __init__(self, checkpoints_path):
-        self.checkpoints_path = checkpoints_path
-        # Placeholder for dataset loading logic
+class ckpt_set(Dataset):
+    def __init__(self, p):
+        self.p = Path(p)
+        self.fs = sorted(self.p.glob('*.pt'))
 
     def __len__(self):
-        # Placeholder
-        return 0
+        return len(self.fs)
 
-    def __getitem__(self, idx):
-        # Placeholder
-        return None
+    def __getitem__(self, i):
+        w = torch.load(self.fs[i], map_location='cpu')
+        return flat(w)
+

--- a/src/utils/flatten.py
+++ b/src/utils/flatten.py
@@ -1,0 +1,8 @@
+import torch
+
+def flat(d):
+    r = []
+    for k in sorted(d):
+        r.append(d[k].reshape(-1))
+    return torch.cat(r)
+


### PR DESCRIPTION
## Summary
- add residual net backbone
- add checkpoint dataset and flatten helpers
- implement generator and training entrypoint

## Testing
- `python run.py --experiment_path experiments/tmp_exp`


------
https://chatgpt.com/codex/tasks/task_e_6899194d73dc8321ad3099d0647969ca