### PR TITLE
Integrate timestep-aware generator

### DIFF
--- a/src/diffusion/generator.py
+++ b/src/diffusion/generator.py
@@ -1,10 +1,19 @@
+import torch
 import torch.nn as nn
 
 class model_ref(nn.Module):
     def __init__(self, n):
         super().__init__()
-        self.l = nn.Linear(n, n)
+        self.tm1 = nn.Linear(1, n)
+        self.lm1 = nn.Linear(n * 2, n)
 
-    def forward(self, x):
-        return self.l(x)
+    def forward(self, w, t):
+        e = self.tm1(t)
+        x = torch.cat([w, e], 1)
+        return self.lm1(x)
+
+# KEY
+# model_ref: next weight estimator
+# tm1: timestep embedding layer
+# lm1: weight mapping layer
 

--- a/src/diffusion/train_generator.py
+++ b/src/diffusion/train_generator.py
@@ -7,16 +7,20 @@ from src.utils.data import ckpt_set
 def train(cfg):
     ds = ckpt_set(cfg['dataset'])
     dl = DataLoader(ds, batch_size=cfg['hyperparameters']['batch_size'], shuffle=True)
-    n = ds[0].numel()
+    w0, _, _ = ds[0]
+    n = w0.numel()
     m = gen(n)
     opt = torch.optim.Adam(m.parameters(), lr=cfg['hyperparameters']['learning_rate'])
-    loss = nn.MSELoss()
+    mse = nn.MSELoss()
     for _ in range(cfg['hyperparameters']['epochs']):
-        for d in dl:
-            o = m(d)
-            l = loss(o, d)
+        for w0, w1, t in dl:
+            o = m(w0, t)
+            l = mse(o, w1)
             opt.zero_grad()
             l.backward()
             opt.step()
     return m
+
+# KEY
+# train: parameter optimizer for generator using weight pairs and timestep
 

--- a/src/utils/data.py
+++ b/src/utils/data.py
@@ -7,11 +7,17 @@ class ckpt_set(Dataset):
     def __init__(self, p):
         self.p = Path(p)
         self.fs = sorted(self.p.glob('*.pt'))
+        self.n = len(self.fs) - 1
 
     def __len__(self):
-        return len(self.fs)
+        return self.n
 
     def __getitem__(self, i):
-        w = torch.load(self.fs[i], map_location='cpu')
-        return flat(w)
+        w0 = torch.load(self.fs[i], map_location='cpu')
+        w1 = torch.load(self.fs[i + 1], map_location='cpu')
+        t = torch.tensor([i / self.n], dtype=torch.float32)
+        return flat(w0), flat(w1), t
+
+# KEY
+# ckpt_set: dataset of consecutive weight pairs with timestep
 


### PR DESCRIPTION
## Summary
- yield consecutive weight pairs with timestep in checkpoint dataset
- train generator on paired weights and time with MSE target
- add timestep-conditioned generator model for next-weight prediction

## Testing
- `python -m py_compile src/utils/data.py src/diffusion/generator.py src/diffusion/train_generator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c59787020832190ef091fa81a9cdb