### PR TITLE
Use deterministic key order

### DIFF
--- a/src/diffusion_adv/diffusion_model.py
+++ b/src/diffusion_adv/diffusion_model.py
@@ -158,13 +158,15 @@ def get_target_model_flat_dim(target_model_state_dict):
 def flatten_state_dict(state_dict):
     return torch.cat([p.flatten() for p in state_dict.values()])
 
-def unflatten_to_state_dict(flat_params, reference_state_dict):
+def unflatten_to_state_dict(flat_params, reference_state_dict, ks=None):
     new_state_dict = {}
     current_pos = 0
-    for key, param_ref in reference_state_dict.items():
+    if ks is None:
+        ks = list(reference_state_dict.keys())
+    for k in ks:
+        param_ref = reference_state_dict[k]
         num_elements = param_ref.numel()
-        shape = param_ref.shape
-        new_state_dict[key] = flat_params[current_pos : current_pos + num_elements].view(shape)
+        new_state_dict[k] = flat_params[current_pos : current_pos + num_elements].view(param_ref.shape)
         current_pos += num_elements
     if current_pos != flat_params.numel():
         raise ValueError("Mismatch in number of elements during unflattening.")

--- a/src/utils/flatten.py
+++ b/src/utils/flatten.py
@@ -1,8 +1,13 @@
 import torch
 
-def flat(d):
+def flat(d, ks=None):
     r = []
-    for k in sorted(d):
+    if ks is None:
+        ks = list(d.keys())
+    for k in ks:
         r.append(d[k].reshape(-1))
     return torch.cat(r)
+
+# KEY
+# flat: flattener
 


### PR DESCRIPTION
## Summary
- iterate tensors in provided or insertion order when flattening
- restore tensors using matching key order

## Testing
- `python -m py_compile src/utils/flatten.py src/diffusion_adv/diffusion_model.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c597c2bd08321aac9ed4f78caccfc